### PR TITLE
Fix save path layout

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -5,7 +5,7 @@ import TextInput from "../components/TextInput";
 import Button from "../components/Button";
 import "../styles/Form.css"
 
-const Form = ({ fields, onSubmit }) => {
+const Form = ({ fields, onSubmit, buttonText = "Submit" }) => {
   const { setServerMessage } = useContext(UserContext);
 
   const {
@@ -43,7 +43,7 @@ const Form = ({ fields, onSubmit }) => {
           />
         ))}
         <div className="centered-button">
-          <Button type="submit" text="Submit" />
+          <Button type="submit" text={buttonText} />
         </div>
       </form>
     </div>

--- a/src/pages/PathMaker.jsx
+++ b/src/pages/PathMaker.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { useForm } from "react-hook-form";
 import PathContext from "../contexts/PathContextBase";
 import {
   MapContainer,
@@ -21,12 +20,6 @@ import "../styles/PathMaker.css";
 const PathMaker = () => {
   const [token, setToken] = useState("");
   const [loading, setLoading] = useState(false);
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm();
 
   const {
     setTitle,

--- a/src/pages/PathMaker.jsx
+++ b/src/pages/PathMaker.jsx
@@ -13,14 +13,12 @@ import "leaflet/dist/leaflet.css";
 import GetUserPosition from "../components/GetUserPosition";
 import Timer from "../components/Timer";
 import MapUpdater from "../components/UpdateMapPosition";
-import Button from "../components/Button";
-import TextInput from "../components/TextInput";
 import { savePath } from "../services/pathApi";
-import UserContext from "../contexts/UserContextBase";
+import Form from "../components/Form";
+import Loading from "../components/Loading"
+import "../styles/PathMaker.css";
 
 const PathMaker = () => {
-
-  const { setServerMessage } = useContext(UserContext);
   const [token, setToken] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -40,6 +38,14 @@ const PathMaker = () => {
     savedTime,
   } = useContext(PathContext);
 
+  const fields = [
+    {
+      name: "title",
+      label: "Path Title",
+      validation: { required: "A title is required" },
+    },
+  ];
+
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -53,20 +59,16 @@ const PathMaker = () => {
 
   const onSubmit = async (data) => {
     setLoading(true);
-    setTitle(data.title);
     const pathData = {
       waypoints: route,
       title: data.title,
       distance: distance,
       time: savedTime,
     };
-    try {
-      const response = await savePath(pathData);
-      setServerMessage({ type: "success", text: response.message });
-    } catch (error){
-      setServerMessage({ type: "failed", text: error.message });
-    }
+    const response = await savePath(pathData);
+    setTitle(data.title);
     setLoading(false);
+    return response
   };
 
   return (
@@ -94,28 +96,22 @@ const PathMaker = () => {
             {route.length > 0 && <Polyline positions={route} color="blue" />}
           </MapContainer>
         </div>
-
-        <GetUserPosition
-          onPositionUpdate={setPosition}
-          onRouteUpdate={setRoute}
-        />
+        { !loading && (
+        <div className="container-position-save">
+          <GetUserPosition
+            onPositionUpdate={setPosition}
+            onRouteUpdate={setRoute}
+          />
+          {route && route.length > 0 && (
+              <Form fields={fields} onSubmit={onSubmit} buttonText="Save path"/>
+            
+          )}
+        </div>)
+        }
+        {loading &&
+        <Loading />        }
 
         <Timer />
-        {route && route.length > 0 && (
-          <div>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <TextInput
-                name="title"
-                label="Give your route a title"
-                register={register}
-                registerOptions={{ required: "A title for the route is required" }}
-                error={errors.username}
-                required
-              />
-              <Button text={"Save path"} type="submit" />
-            </form>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/styles/PathMaker.css
+++ b/src/styles/PathMaker.css
@@ -1,0 +1,15 @@
+.container-position-save {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  .form-container {
+    margin: 0;
+    max-width: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .container-position-save {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION

Fixed the layout for PathMaker - it should be responsive now (set distance and save path are side by side in desktop and stack in a column at 768px via media query

Add buttonText prop to forms so now we can say for example 
<Form buttonText="Login" /> 
and have the button show Login instead of Submit, 
if form is entered without buttonText it will default to Submit (so nothing breaks):
< Form />